### PR TITLE
update cmake_minimum_required

### DIFF
--- a/cmake/modules/hunter_apply_gate_settings.cmake
+++ b/cmake/modules/hunter_apply_gate_settings.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include(CMakeParseArguments) # cmake_parse_arguments
 

--- a/cmake/modules/hunter_boost_component_b2_args.cmake
+++ b/cmake/modules/hunter_boost_component_b2_args.cmake
@@ -2,7 +2,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # for iostreams dependency on ZLIB and BZIP2
 include(hunter_add_package)

--- a/cmake/modules/hunter_calculate_config_sha1.cmake
+++ b/cmake/modules/hunter_calculate_config_sha1.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include(hunter_assert_not_empty_string)
 include(hunter_config)

--- a/cmake/modules/hunter_calculate_self.cmake
+++ b/cmake/modules/hunter_calculate_self.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include(hunter_internal_error)
 include(hunter_assert_not_empty_string)

--- a/cmake/modules/hunter_lock_directory.cmake
+++ b/cmake/modules/hunter_lock_directory.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include(hunter_fatal_error)
 include(hunter_status_debug)

--- a/cmake/modules/hunter_make_directory.cmake
+++ b/cmake/modules/hunter_make_directory.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include(hunter_internal_error)
 include(hunter_lock_directory)

--- a/cmake/modules/hunter_set_config_location.cmake
+++ b/cmake/modules/hunter_set_config_location.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include(hunter_internal_error)
 include(hunter_status_print)

--- a/cmake/modules/hunter_setup_msvc.cmake
+++ b/cmake/modules/hunter_setup_msvc.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2014-2016, Ruslan Baratov, Sumedh Ghaisas
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include(hunter_fatal_error)
 include(hunter_internal_error)

--- a/cmake/projects/Avahi/schemes/url_sha1_avahi_autotools.cmake.in
+++ b/cmake/projects/Avahi/schemes/url_sha1_avahi_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 list(APPEND CMAKE_MODULE_PATH "@HUNTER_SELF@/cmake/modules")

--- a/cmake/projects/Boost/schemes/url_sha1_boost.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/Boost/schemes/url_sha1_boost_ios_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_ios_library.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/NASM/schemes/url_sha1_nasm_windows.cmake.in
+++ b/cmake/projects/NASM/schemes/url_sha1_nasm_windows.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Zhuhao Wang
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/OpenBLAS/schemes/OpenBLAS.cmake.in
+++ b/cmake/projects/OpenBLAS/schemes/OpenBLAS.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2016 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/OpenSSL/ep-stages/configure.cmake.in
+++ b/cmake/projects/OpenSSL/ep-stages/configure.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 if(NOT "@NASM_ROOT@" STREQUAL "")
   set(ENV{PATH} "@NASM_ROOT@/bin;$ENV{PATH}")

--- a/cmake/projects/OpenSSL/ep-stages/configure_1_1_plus.cmake.in
+++ b/cmake/projects/OpenSSL/ep-stages/configure_1_1_plus.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 if(NOT "@NASM_ROOT@" STREQUAL "")
   set(ENV{PATH} "@NASM_ROOT@/bin;$ENV{PATH}")

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl_ios.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl_ios.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl_macos.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl_macos.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl_windows.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl_windows.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2014, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl_windows_1_1_plus.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl_windows_1_1_plus.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/Qt/ep-stages/qt-build.cmake.in
+++ b/cmake/projects/Qt/ep-stages/qt-build.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 ### Input params check
 

--- a/cmake/projects/Qt/ep-stages/qt-configure.cmake.in
+++ b/cmake/projects/Qt/ep-stages/qt-configure.cmake.in
@@ -1,5 +1,5 @@
 ### Input params check
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 string(COMPARE EQUAL "@configure_command@" "" is_empty)
 if(is_empty)

--- a/cmake/projects/Qt/ep-stages/qt-install.cmake.in
+++ b/cmake/projects/Qt/ep-stages/qt-install.cmake.in
@@ -1,5 +1,5 @@
 ### Input params check
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 string(COMPARE EQUAL "@global_install_dir@" "" is_empty)
 if(is_empty)

--- a/cmake/projects/Qt/schemes/url_sha1_qt.cmake.in
+++ b/cmake/projects/Qt/schemes/url_sha1_qt.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015-2016 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/botan/schemes/url_sha1_botan.cmake.in
+++ b/cmake/projects/botan/schemes/url_sha1_botan.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(Hunter)
 

--- a/cmake/projects/botan/schemes/url_sha1_botan_ios.cmake.in
+++ b/cmake/projects/botan/schemes/url_sha1_botan_ios.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(Hunter)
 

--- a/cmake/projects/botan/schemes/url_sha1_botan_macos.cmake.in
+++ b/cmake/projects/botan/schemes/url_sha1_botan_macos.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(Hunter)
 

--- a/cmake/projects/botan/schemes/url_sha1_botan_win.cmake.in
+++ b/cmake/projects/botan/schemes/url_sha1_botan_win.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(Hunter)
 

--- a/cmake/projects/flex/schemes/url_sha1_flex_autotools.cmake.in
+++ b/cmake/projects/flex/schemes/url_sha1_flex_autotools.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 list(APPEND CMAKE_MODULE_PATH "@HUNTER_SELF@/cmake/modules")

--- a/cmake/projects/libsodium/schemes/url_sha1_libsodium_autogen_autotools.cmake.in
+++ b/cmake/projects/libsodium/schemes/url_sha1_libsodium_autogen_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 list(APPEND CMAKE_MODULE_PATH "@HUNTER_SELF@/cmake/modules")

--- a/cmake/projects/libsodium/schemes/url_sha1_libsodium_msbuild.cmake.in
+++ b/cmake/projects/libsodium/schemes/url_sha1_libsodium_msbuild.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 

--- a/cmake/projects/libxml2/schemes/url_sha1_libxml2_msvc.cmake.in
+++ b/cmake/projects/libxml2/schemes/url_sha1_libxml2_msvc.cmake.in
@@ -2,7 +2,7 @@
 # Copyright (c) 2017, Sacha Refshauge
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/odb-boost/schemes/url_sha1_odb-boost_autotools.cmake.in
+++ b/cmake/projects/odb-boost/schemes/url_sha1_odb-boost_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2016 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include("@HUNTER_SELF@/cmake/Hunter")

--- a/cmake/projects/odb-mysql/schemes/url_sha1_odb-mysql_autotools.cmake.in
+++ b/cmake/projects/odb-mysql/schemes/url_sha1_odb-mysql_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2016 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include("@HUNTER_SELF@/cmake/Hunter")

--- a/cmake/projects/odb-pgsql/schemes/url_sha1_odb-pgsql_autotools.cmake.in
+++ b/cmake/projects/odb-pgsql/schemes/url_sha1_odb-pgsql_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2016 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include("@HUNTER_SELF@/cmake/Hunter")

--- a/cmake/projects/odb-sqlite/schemes/url_sha1_odb-sqlite_autotools.cmake.in
+++ b/cmake/projects/odb-sqlite/schemes/url_sha1_odb-sqlite_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include("@HUNTER_SELF@/cmake/Hunter")

--- a/cmake/projects/tcl/schemes/url_sha1_tcl_autotools.cmake.in
+++ b/cmake/projects/tcl/schemes/url_sha1_tcl_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include("@HUNTER_SELF@/cmake/Hunter")

--- a/cmake/projects/x264/schemes/url_sha1_x264.cmake.in
+++ b/cmake/projects/x264/schemes/url_sha1_x264.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2017 Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/xcb/schemes/xcb.cmake.in
+++ b/cmake/projects/xcb/schemes/xcb.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2016 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include("@HUNTER_SELF@/cmake/Hunter")

--- a/cmake/schemes/url_sha1_autogen_autotools.cmake.in
+++ b/cmake/schemes/url_sha1_autogen_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 list(APPEND CMAKE_MODULE_PATH "@HUNTER_SELF@/cmake/modules")

--- a/cmake/schemes/url_sha1_autotools.cmake.in
+++ b/cmake/schemes/url_sha1_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include("@HUNTER_SELF@/cmake/Hunter")

--- a/cmake/schemes/url_sha1_cmake.cmake.in
+++ b/cmake/schemes/url_sha1_cmake.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/schemes/url_sha1_download.cmake.in
+++ b/cmake/schemes/url_sha1_download.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2015 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/schemes/url_sha1_ios_sim.cmake.in
+++ b/cmake/schemes/url_sha1_ios_sim.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/schemes/url_sha1_unpack.cmake.in
+++ b/cmake/schemes/url_sha1_unpack.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include(ExternalProject) # ExternalProject_Add
 

--- a/cmake/schemes/url_sha1_unpack_bin_install.cmake.in
+++ b/cmake/schemes/url_sha1_unpack_bin_install.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Zhuhao Wang
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/schemes/url_sha1_unpack_install.cmake.in
+++ b/cmake/schemes/url_sha1_unpack_install.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2015 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Unpack the archive and copy contents to HUNTER_PACKAGE_INSTALL_PREFIX
 

--- a/scripts/append-boost-config-macros.cmake.in
+++ b/scripts/append-boost-config-macros.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # run at the boost source root
 set(boost_user_config_file "boost/config/user.hpp")

--- a/scripts/autotools-merge-lipo.cmake.in
+++ b/scripts/autotools-merge-lipo.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, 2019 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 ### Input params check
 

--- a/scripts/clean-boost-configs.cmake
+++ b/scripts/clean-boost-configs.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 if("${installdir}" STREQUAL "")
   message(FATAL_ERROR "installdir is empty")

--- a/scripts/create-toolchain-info.cmake
+++ b/scripts/create-toolchain-info.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(HunterToolchain)
 
 if(NOT HUNTER_SELF)

--- a/scripts/find_python.cmake
+++ b/scripts/find_python.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 find_package(PythonInterp 3 QUIET)
 

--- a/scripts/link-all.cmake
+++ b/scripts/link-all.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 string(COMPARE EQUAL "${HUNTER_INSTALL_PREFIX}" "" is_empty)
 if(is_empty)

--- a/scripts/try-copy-license.cmake
+++ b/scripts/try-copy-license.cmake
@@ -2,7 +2,7 @@
 # Copyright (c) 2017 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 string(COMPARE EQUAL "${srcdir}" "" is_empty)
 if(is_empty)


### PR DESCRIPTION
Fix `cmake_minimum_required` deprecation warning.

Updated in upstream https://github.com/cpp-pm/hunter/pull/689.